### PR TITLE
Add Initialize Action

### DIFF
--- a/src/CopyUtils/PropertyChange.cs
+++ b/src/CopyUtils/PropertyChange.cs
@@ -6,7 +6,7 @@ namespace AReSSO.CopyUtils
     public struct PropertyChange<T>
     {
         /// <summary>Whether or not the value this PropertyChange represents has actually been changed.</summary>
-        public bool Changed { get; }
+        private bool Changed { get; }
         /// <summary>The new value.</summary>
         private T Value { get; }
 

--- a/src/Store/InitialStateTypeMismatchException.cs
+++ b/src/Store/InitialStateTypeMismatchException.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Reflection;
+
+namespace AReSSO.Store
+{
+    public class InitialStateTypeMismatchException : Exception
+    {
+        public InitialStateTypeMismatchException(MemberInfo givenType, MemberInfo expectedType)
+            : base(
+                $"The given root state type ({givenType.Name}) does not match" +
+                $"the expected root state type for this store ({expectedType.Name})."
+            )
+        {
+        }
+    }
+}

--- a/src/Store/InitialStateTypeMismatchException.cs.meta
+++ b/src/Store/InitialStateTypeMismatchException.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 962d3aeb937c4970a806481456c39eef
+timeCreated: 1583198378

--- a/src/Store/InitializeAction.cs
+++ b/src/Store/InitializeAction.cs
@@ -1,12 +1,8 @@
 namespace AReSSO.Store
 {
     /// <summary>
-    /// The InitializeAction is a special reserved action which must be used to initialize a Store.
+    /// The InitializeAction is a special reserved action which can be used to initialize a Store.
     /// </summary>
-    /// <remarks>
-    /// If a store is not initialized with this action prior to being used,
-    /// it will throw a StoreNotInitializedException.
-    /// </remarks>
     public class InitializeAction<TRootState> : IAction
     {
         public TRootState InitialState { get; }

--- a/src/Store/InitializeAction.cs
+++ b/src/Store/InitializeAction.cs
@@ -1,0 +1,16 @@
+namespace AReSSO.Store
+{
+    /// <summary>
+    /// The InitializeAction is a special reserved action which must be used to initialize a Store.
+    /// </summary>
+    /// <remarks>
+    /// If a store is not initialized with this action prior to being used,
+    /// it will throw a StoreNotInitializedException.
+    /// </remarks>
+    public class InitializeAction<TRootState> : IAction
+    {
+        public TRootState InitialState { get; }
+
+        public InitializeAction(TRootState initialState) => InitialState = initialState;
+    }
+}

--- a/src/Store/InitializeAction.cs.meta
+++ b/src/Store/InitializeAction.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c5e7875b2dd04bf48a2d9a26b8350a63
+timeCreated: 1583117881

--- a/src/Store/StoreBehaviour.cs
+++ b/src/Store/StoreBehaviour.cs
@@ -11,7 +11,7 @@ namespace AReSSO.Store
     /// StoreBehaviour is abstract because you, the developer, must define a sublcass of it in order to initialize the
     /// store correctly.
     /// </remarks>
-    public abstract class StoreBehaviour<TRootState> : MonoBehaviour, IStore<TRootState>
+    public abstract class StoreBehaviour<TRootState> : MonoBehaviour, IStore<TRootState> where TRootState : class
     {
         public Store<TRootState> Store { get; private set; }
         

--- a/src/Store/StoreNotInitializedException.cs
+++ b/src/Store/StoreNotInitializedException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace AReSSO.Store
+{
+    public class StoreNotInitializedException : Exception
+    {
+        public StoreNotInitializedException()
+            : base(
+                "This Store has not been initialized. To initialize a Store you must dispatch the " +
+                "InitializeAction to it."
+            )
+        {
+        }
+    }
+}

--- a/src/Store/StoreNotInitializedException.cs.meta
+++ b/src/Store/StoreNotInitializedException.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cc9900fce49e4cc78d365f74be8a1efb
+timeCreated: 1583196163

--- a/test/DispatchedActionTests.cs
+++ b/test/DispatchedActionTests.cs
@@ -15,7 +15,7 @@ namespace AReSSO.Test
             var now = DateTime.Now;
             var da = new DispatchedAction(new TestAction());
             
-            Assert.That(da.DispatchTime, Is.EqualTo(now).Within(TimeSpan.FromMilliseconds(5)));
+            Assert.That(da.DispatchTime, Is.EqualTo(now).Within(TimeSpan.FromMilliseconds(10)));
         }
 
         [Test]

--- a/test/Point.cs
+++ b/test/Point.cs
@@ -16,15 +16,8 @@ namespace AReSSO.Test
 
         public Point Copy(
             PropertyChange<float> x = default,
-            PropertyChange<float> y = default)
-        {
-            if (x.Changed || y.Changed)
-            {
-                return new Point(x.Else(X), y.Else(Y));
-            }
-
-            return this;
-        }
+            PropertyChange<float> y = default) =>
+            new Point(x.Else(X), y.Else(Y));
 
         public bool Equals(Point other)
         {

--- a/test/SimpleTestState.cs
+++ b/test/SimpleTestState.cs
@@ -11,15 +11,7 @@ namespace AReSSO.Test
             N = n;
         }
         
-        public SimpleTestState Copy(PropertyChange<int> n = default)
-        {
-            if (n.Changed)
-            {
-                return new SimpleTestState(n.Else(N));
-            }
-
-            return this;
-        }
+        public SimpleTestState Copy(PropertyChange<int> n = default) => new SimpleTestState(n.Else(N));
 
         protected bool Equals(SimpleTestState other)
         {

--- a/usageExamples/ExampleStoreBehaviour.cs
+++ b/usageExamples/ExampleStoreBehaviour.cs
@@ -5,16 +5,17 @@ namespace AReSSO.UsageExamples
 {
     public class ExampleStoreBehaviour : StoreBehaviour<ExampleGroup>
     {
-        private readonly ExamplePerson[] initialPeople = new[]
-        {
+        private readonly ExamplePerson[] initialPeople = {
             new ExamplePerson("Alice", new DateTime(1980, 01, 01), new ExampleSong[] { }),
             new ExamplePerson("Bob", new DateTime(1800, 12, 31), new ExampleSong[] { }),
             new ExamplePerson("Charlie", new DateTime(0, 0, 0), new ExampleSong[] { })
         };
         
         // Override InitializeStore to set the initial state and root reducer.
-        protected override Store<ExampleGroup> InitializeStore() =>
-            new Store<ExampleGroup>(new ExampleGroup(initialPeople), RootReducer);
+        protected override Store<ExampleGroup> InitializeStore()
+        {
+            return new Store<ExampleGroup>(new ExampleGroup(initialPeople), RootReducer);
+        }
 
         // This is the most basic reducer, the identity reducer. It doesn't do anything.
         private static ExampleGroup RootReducer(ExampleGroup state, IAction action) => state;


### PR DESCRIPTION
 - The `InitializeAction` is a "reserved" action that initializes the store it is dispatched to with an initial state.
 - Store still takes in an initial state when it is constructed, and internally dispatches an `InitializeAction` to initialize itself.
 - Client code can itself dispatch an `InitializeAction` to reinitialize the store from scratch.
 - Update tests to reflect this.